### PR TITLE
feat(common): add globe icon to LanguageSwitcher and improve mobile UX

### DIFF
--- a/src/app/[locale]/_components/common/LanguageSwitcher.tsx
+++ b/src/app/[locale]/_components/common/LanguageSwitcher.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useRouter } from "@/i18n/navigation";
 import { LANGUAGES } from "../../_constants/language";
 import { useTranslations } from "next-intl";
+import { FaGlobe } from "react-icons/fa";
 
 export default function LanguageSwitcher() {
   const pathname = usePathname();
@@ -15,8 +16,9 @@ export default function LanguageSwitcher() {
 
   return (
     <div className="dropdown dropdown-end">
-      <button className="btn btn-ghost rounded-field">
-        {t("language")}
+      <button className="btn btn-ghost rounded-field flex items-center gap-2">
+        <FaGlobe className="text-lg" />
+        <span className="hidden md:inline">{t("language")}</span>
       </button>
       <ul className="menu dropdown-content bg-base-200 rounded-box z-1 mt-4 w-52 p-2 shadow-sm">
         {LANGUAGES.map((lang) => (


### PR DESCRIPTION
- Add FaGlobe icon to the left of the language switcher button
- Hide language text on mobile, show only icon
- Keep dropdown menu with flag and language name
- Improve accessibility and responsive design